### PR TITLE
04-network-blocking/examples: Add proper includes

### DIFF
--- a/materials/04-network-blocking/examples/client.c
+++ b/materials/04-network-blocking/examples/client.c
@@ -1,5 +1,8 @@
+#include <strings.h>
+#include <unistd.h>
 #include <sys/types.h>
 #include <sys/socket.h>
+#include <arpa/inet.h>
 #include <netdb.h>
 #include <stdio.h>
 #include<string.h>

--- a/materials/04-network-blocking/examples/server.c
+++ b/materials/04-network-blocking/examples/server.c
@@ -1,3 +1,5 @@
+#include <strings.h>
+#include <unistd.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netdb.h>

--- a/materials/04-network-blocking/examples/server2.c
+++ b/materials/04-network-blocking/examples/server2.c
@@ -1,3 +1,5 @@
+#include <strings.h>
+#include <unistd.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netdb.h>


### PR DESCRIPTION
This gets rid of implicit declarations.