### PR TITLE
unique_ptr to shared_ptr for incomplete type Execute::Command

### DIFF
--- a/src/network/uv/Worker.h
+++ b/src/network/uv/Worker.h
@@ -99,7 +99,7 @@ protected:
         Protocol::Parser parser;
 
         // Command parsed out from the input
-        std::unique_ptr<Execute::Command> cmd;
+        std::shared_ptr<Execute::Command> cmd;
 
         // Number of bytes left to read to get command
         uint32_t body_size;
@@ -135,7 +135,7 @@ protected:
         Connection *connection;
 
         // Command to execute
-        std::unique_ptr<Execute::Command> cmd;
+        std::shared_ptr<Execute::Command> cmd;
 
         // Argument for the command
         std::string argument;

--- a/src/protocol/Parser.cpp
+++ b/src/protocol/Parser.cpp
@@ -160,20 +160,20 @@ bool Parser::Parse(const char *input, const size_t size, size_t &parsed) {
 }
 
 // See Parse.h
-std::unique_ptr<Execute::Command> Parser::Build(uint32_t &body_size) const {
+std::shared_ptr<Execute::Command> Parser::Build(uint32_t &body_size) const {
     if (state != State::sLF) {
         return std::unique_ptr<Execute::Command>(nullptr);
     }
 
     body_size = bytes;
     if (name == "set") {
-        return std::unique_ptr<Execute::Command>(new Execute::Set(keys[0], flags, exprtime));
+        return std::shared_ptr<Execute::Command>(new Execute::Set(keys[0], flags, exprtime));
     } else if (name == "add") {
-        return std::unique_ptr<Execute::Command>(new Execute::Add(keys[0], flags, exprtime));
+        return std::shared_ptr<Execute::Command>(new Execute::Add(keys[0], flags, exprtime));
     } else if (name == "append") {
-        return std::unique_ptr<Execute::Command>(new Execute::Append(keys[0], flags, exprtime));
+        return std::shared_ptr<Execute::Command>(new Execute::Append(keys[0], flags, exprtime));
     } else if (name == "get") {
-        return std::unique_ptr<Execute::Command>(new Execute::Get(keys));
+        return std::shared_ptr<Execute::Command>(new Execute::Get(keys));
     } else {
         throw new std::runtime_error("Unsupported command");
     }

--- a/src/protocol/Parser.h
+++ b/src/protocol/Parser.h
@@ -46,7 +46,7 @@ public:
      * Builds new command from parsed input. In case if it wasn't enough input to prse command out
      * method return nullptr
      */
-    std::unique_ptr<Execute::Command> Build(uint32_t &body_size) const;
+    std::shared_ptr<Execute::Command> Build(uint32_t &body_size) const;
 
     /**
      * Reset parse so that it could be used to parse out new command

--- a/test/protocol/MemcachedParserTest.cpp
+++ b/test/protocol/MemcachedParserTest.cpp
@@ -26,7 +26,7 @@ TEST(MemcachedParserTest, SimpleSet) {
     ASSERT_EQ("set", parser.Name());
 
     uint32_t value_size;
-    std::unique_ptr<Execute::Command> cmd = parser.Build(value_size);
+    std::shared_ptr<Execute::Command> cmd = parser.Build(value_size);
     ASSERT_FALSE(cmd == nullptr);
     ASSERT_EQ(6, value_size);
 
@@ -47,7 +47,7 @@ TEST(MemcachedParserTest, SimpleAdd) {
     ASSERT_EQ("add", parser.Name());
 
     uint32_t value_size;
-    std::unique_ptr<Execute::Command> cmd = parser.Build(value_size);
+    std::shared_ptr<Execute::Command> cmd = parser.Build(value_size);
     ASSERT_FALSE(cmd == nullptr);
     ASSERT_EQ(60, value_size);
 
@@ -68,7 +68,7 @@ TEST(MemcachedParserTest, SimpleGet) {
     ASSERT_EQ("get", parser.Name());
 
     uint32_t value_size;
-    std::unique_ptr<Execute::Command> cmd = parser.Build(value_size);
+    std::shared_ptr<Execute::Command> cmd = parser.Build(value_size);
     ASSERT_FALSE(cmd == nullptr);
     ASSERT_EQ(0, value_size);
 


### PR DESCRIPTION
As we want to create <>_ptr<Execute::Command> we need use shared_ptr instead of unique_ptr, because shared_ptr support an incomplete types
http://en.cppreference.com/w/cpp/memory/unique_ptr

std::unique_ptr may be constructed for an incomplete type T, such as to facilitate the use as a handle in the pImpl idiom. If the default deleter is used, T must be complete at the point in code where the deleter is invoked, which happens in the destructor, move assignment operator, and reset member function of std::unique_ptr. (Conversely, std::shared_ptr can't be constructed from a raw pointer to incomplete type, but can be destroyed where T is incomplete). Note that if T is a class template specialization, use of unique_ptr as an operand, e.g. !p requires T's parameters to be complete due to ADL.

If T is a derived class of some base B, then std::unique_ptr<T> is implicitly convertible to std::unique_ptr<B>. The default deleter of the resulting std::unique_ptr<B> will use operator delete for B, leading to undefined behavior unless the destructor of B is virtual. Note that std::shared_ptr behaves differently: std::shared_ptr<B> will use the operator delete for the type T and the owned object will be deleted correctly even if the destructor of B is not virtual.

Unlike std::shared_ptr, std::unique_ptr may manage an object through any custom handle type that satisfies NullablePointer. This allows, for example, managing objects located in shared memory, by supplying a Deleter that defines typedef boost::offset_ptr pointer; or another fancy pointer.
