### PR TITLE
Совместимость с memcached add, set, replace, append, get

### DIFF
--- a/src/execute/Add.cpp
+++ b/src/execute/Add.cpp
@@ -1,14 +1,16 @@
-#include <afina/execute/Add.h>
 #include <afina/Storage.h>
+#include <afina/execute/Add.h>
 
 #include <iostream>
 
 namespace Afina {
 namespace Execute {
 
+// memcached protocol:  "add" means "store this data, but only if the server *doesn't* already
+// hold data for this key".
 void Add::Execute(Storage &storage, const std::string &args, std::string &out) {
     std::cout << "Add(" << _key << ")" << args << std::endl;
-    storage.Put(_key, args);
+    out = storage.PutIfAbsent(_key, args) ? "STORED" : "NOT_STORED";
 }
 
 } // namespace Execute

--- a/src/execute/Append.cpp
+++ b/src/execute/Append.cpp
@@ -1,16 +1,21 @@
-#include <afina/execute/Append.h>
 #include <afina/Storage.h>
+#include <afina/execute/Append.h>
 
 #include <iostream>
 
 namespace Afina {
 namespace Execute {
 
+// memcached protocol: "append" means "add this data to an existing key after existing data".
 void Append::Execute(Storage &storage, const std::string &args, std::string &out) {
     std::cout << "Append(" << _key << ")" << args << std::endl;
     std::string value;
-    storage.Get(_key, value);
-    out = storage.Put(_key, value + args);
+    if (!storage.Get(_key, value)) {
+        out.assign("NOT_STORED");
+        return;
+    }
+    storage.Put(_key, value + args);
+    out.assign("STORED");
 }
 
 } // namespace Execute

--- a/src/execute/Get.cpp
+++ b/src/execute/Get.cpp
@@ -35,7 +35,7 @@ void Get::Execute(Storage &storage, const std::string &args, std::string &out) {
         outStream << "VALUE " << key << " 0 " << value.size() << "\r\n";
         outStream << value << "\r\n";
     }
-    outStream << "END\r\n";
+    outStream << "END"; // networking layer should add the last \r\n
 
     out = outStream.str();
 }

--- a/src/execute/Get.cpp
+++ b/src/execute/Get.cpp
@@ -1,25 +1,41 @@
-#include <afina/execute/Get.h>
 #include <afina/Storage.h>
+#include <afina/execute/Get.h>
 
-#include <sstream>
-#include <iterator>
 #include <iostream>
+#include <iterator>
+#include <sstream>
 
 namespace Afina {
 namespace Execute {
 
+/* memcached protocol:
+
+Each item sent by the server looks like this:
+
+VALUE <key> <flags> <bytes>\r\n
+<data block>\r\n
+
+After all the items have been transmitted, the server sends the string
+"END\r\n"
+to indicate the end of response.
+
+*/
+
 void Get::Execute(Storage &storage, const std::string &args, std::string &out) {
     std::stringstream keyStream;
-    copy(_keys.begin(),_keys.end(), std::ostream_iterator<std::string>(keyStream," "));
+    copy(_keys.begin(), _keys.end(), std::ostream_iterator<std::string>(keyStream, " "));
     std::cout << "Get(" << keyStream.str() << ")" << std::endl;
 
     std::stringstream outStream;
 
     std::string value;
-    for (auto& key:_keys) {
-        storage.Get(key,value);
-        outStream << value << " ";
+    for (auto &key : _keys) {
+        if (!storage.Get(key, value))
+            continue;
+        outStream << "VALUE " << key << " 0 " << value.size() << "\r\n";
+        outStream << value << "\r\n";
     }
+    outStream << "END\r\n";
 
     out = outStream.str();
 }

--- a/src/execute/Replace.cpp
+++ b/src/execute/Replace.cpp
@@ -6,9 +6,18 @@
 namespace Afina {
 namespace Execute {
 
+// memcached protocol:  "replace" means "store this data, but only if the server *does*
+// already hold data for this key".
+
 void Replace::Execute(Storage &storage, const std::string &args, std::string &out) {
     std::cout << "Replace(" << _key << "): " << args << std::endl;
-    out = "NOT_STORED";
+    std::string value;
+    if (storage.Get(_key, value)) {
+        storage.Set(_key, args);
+        out = "STORED";
+    } else {
+        out = "NOT_STORED";
+    }
 }
 
 } // namespace Execute

--- a/src/execute/Set.cpp
+++ b/src/execute/Set.cpp
@@ -1,22 +1,16 @@
-#include <afina/execute/Set.h>
 #include <afina/Storage.h>
+#include <afina/execute/Set.h>
 
 #include <iostream>
 
 namespace Afina {
 namespace Execute {
 
+// memcached protocol: "set" means "store this data".
 void Set::Execute(Storage &storage, const std::string &args, std::string &out) {
     std::cout << "Set(" << _key << "): " << args << std::endl;
-
-    std::string value;
-    if (storage.Get(_key, value))
-    {
-        storage.Put(_key, args);
-        out = "STORED";
-    } else {
-        out = "NOT_STORED";
-    }
+    storage.Put(_key, args);
+    out = "STORED";
 }
 
 } // namespace Execute


### PR DESCRIPTION
Протокол memcached: https://github.com/memcached/memcached/blob/master/doc/protocol.txt

Этот коммит исправляет совместимость Афины с ранее реализованными в ней командами:
 - команда add = метод PutIfAbsent (должен проверять, *нет* ли ключа)
 - команда set = метод Put (*не* должен проверять, есть ли ключ)
 - команда replace = метод Set (должен проверять, *есть* ли ключ)
 - команда append должна проверять, *есть* ли ключ, прежде чем добавлять
 - команда get должна возвращать данные в определённом формате (поле flag в данный момент зануляется, cas unique опционально и не выводится вовсе)

Это позволяет заполнить Storage, играя "по правилам" memcached.