### PR TITLE
typo: don't "throw new"

### DIFF
--- a/src/network/memcached/Parser.cpp
+++ b/src/network/memcached/Parser.cpp
@@ -173,7 +173,7 @@ std::unique_ptr<Execute::Command> Parser::Build(uint32_t &body_size) const {
     } else if (name == "get") {
         return std::unique_ptr<Execute::Command>(new Execute::Get(keys));
     } else {
-        throw new std::runtime_error("Unsupported command");
+        throw std::runtime_error("Unsupported command");
     }
 }
 

--- a/src/protocol/Parser.cpp
+++ b/src/protocol/Parser.cpp
@@ -175,7 +175,7 @@ std::unique_ptr<Execute::Command> Parser::Build(uint32_t &body_size) const {
     } else if (name == "get") {
         return std::unique_ptr<Execute::Command>(new Execute::Get(keys));
     } else {
-        throw new std::runtime_error("Unsupported command");
+        throw std::runtime_error("Unsupported command");
     }
 }
 


### PR DESCRIPTION
"throw new" involves heap and requires an appropriate catch
block (catch (std::runtime_error * e) {}) and calling delete
after handling the exception.

Even catching a reference (catch (std::runtime_error & e) {})
doesn't handle a pointer exception.