### PR TITLE
Тесты сетевого слоя

### DIFF
--- a/itest/network_test.pl
+++ b/itest/network_test.pl
@@ -9,9 +9,9 @@ use Test::More tests => 61;
 use IO::Socket::INET;
 use Getopt::Long;
 
-my $backend = "blocking";
+my $backend = $ENV{NETWORK_BACKEND} // "blocking";
 my $silent = 0;
-my $afina = glob "$Bin/../*/src/afina";
+my $afina = $ENV{AFINA_PATH} // glob "$Bin/../*/src/afina";
 
 GetOptions(
 	"backend=s" => \$backend,
@@ -65,11 +65,11 @@ sub afina_request { # 3 tests
 	);
 	ok($socket, "Connected to Afina");
 	ok(print($socket $request), "Sent request");
-	note $request =~ s/^/-> /mrg;
+	$silent or note $request =~ s/^/-> /mrg;
 	ok(shutdown($socket, SHUT_WR()), "Closed writing end of connection");
 	my $received;
 	$received .= $_ while (<$socket>);
-	note $received =~ s/^/<- /mrg;
+	$silent or note $received =~ s/^/<- /mrg;
 	$received;
 }
 

--- a/itest/network_test.pl
+++ b/itest/network_test.pl
@@ -40,7 +40,7 @@ alarm(5);
 }
 
 ok(close($stdin), "Putting Afina to background");
-(threads::->create(sub { my $fh = $_[0]; while(<$fh>) { $silent || diag "afina: $_" } }, $stdout))->detach();
+(threads::->create(sub { my $fh = $_[0]; while(<$fh>) { $silent || note "afina: $_" } }, $stdout))->detach();
 
 alarm(10);
 
@@ -65,11 +65,11 @@ sub afina_request { # 3 tests
 	);
 	ok($socket, "Connected to Afina");
 	ok(print($socket $request), "Sent request");
-	diag $request =~ s/^/-> /mrg;
+	note $request =~ s/^/-> /mrg;
 	ok(shutdown($socket, SHUT_WR()), "Closed writing end of connection");
 	my $received;
 	$received .= $_ while (<$socket>);
-	diag $received =~ s/^/<- /mrg;
+	note $received =~ s/^/<- /mrg;
 	$received;
 }
 
@@ -85,9 +85,9 @@ afina_test("get foo\r\nget foo\r\n", "VALUE foo 0 6\r\nfoobar\r\nEND\r\nVALUE fo
 
 my %par_responses;
 $par_responses{$_}++ for (map { $_->join } map { threads::->create(\&afina_request_silent, $_) } map { sprintf "set bar 0 0 3\r\n%03d\r\n", $_ } 1..100);
-diag "Parallel test responses:";
+note "Parallel test responses:";
 for (sort { $par_responses{$a} <=> $par_responses{$b} } keys %par_responses) {
-	diag "$par_responses{$_} ".($_=~s/([\r\n])/{"\r"=>'\r',"\n"=>'\n'}->{$1}/megr)."\n"
+	note "$par_responses{$_} ".($_=~s/([\r\n])/{"\r"=>'\r',"\n"=>'\n'}->{$1}/megr)."\n"
 }
 ok($par_responses{"STORED\r\n"}, "Afina replied with 'STORED' at least once");
 

--- a/itest/network_test.pl
+++ b/itest/network_test.pl
@@ -11,7 +11,7 @@ use Getopt::Long;
 
 my $backend = "blocking";
 my $silent = 0;
-my $afina = glob "$Bin/../../*/src/afina";
+my $afina = glob "$Bin/../*/src/afina";
 
 GetOptions(
 	"backend=s" => \$backend,

--- a/test/network/test.pl
+++ b/test/network/test.pl
@@ -12,13 +12,14 @@ use Getopt::Long;
 my $backend = "blocking";
 my $silent = 0;
 my $afina = glob "$Bin/../../*/src/afina";
-defined($afina) or die "Couldn't find afina executable, please pass -a <path>\n";
 
 GetOptions(
 	"backend=s" => \$backend,
 	"silent" => \$silent,
 	"afina=s" => \$afina,
 ) or die "Usage: $0 [--backend=backend] [--silent] [--afina=path/to/src/afina]\n";
+
+(defined($afina) and -x $afina) or die "Couldn't find afina executable, please pass -a <path>\n";
 
 my $pid = open3(my $stdin, my $stdout, 0, $afina, "-n", $backend);
 ok $pid, "Started afina with PID=$pid and $backend backend";

--- a/test/network/test.pl
+++ b/test/network/test.pl
@@ -1,0 +1,160 @@
+#!/usr/bin/perl
+use 5.016;
+use warnings;
+use threads;
+use threads::shared;
+use FindBin '$Bin';
+use IPC::Open3;
+use Test::More tests => 53;
+use IO::Socket::INET;
+use Getopt::Long;
+
+my $backend = "blocking";
+my $silent = 0;
+my $afina = glob "$Bin/../../*/src/afina";
+
+GetOptions(
+	"backend=s" => \$backend,
+	"silent" => \$silent,
+	"afina=s" => \$afina,
+) or die "Usage: $0 [--backend=backend] [--silent] [--afina=path/to/src/afina]\n";
+
+my $pid = open3(my $stdin, my $stdout, 0, $afina, "-n", $backend);
+ok $pid, "Started afina with PID=$pid and $backend backend";
+
+local $SIG{ALRM} = sub { kill 'KILL', $pid; die "Timeout\n" };
+alarm(5);
+{
+	my $okay = 0;
+	while (<$stdout>) {
+		if (/Application started/) {
+			alarm(0);
+			$okay = 1;
+			last;
+		}
+	}
+	# if we fell through without finding this line then we have a problem
+	ok $okay, "Afina is waiting for connections";
+}
+
+ok(close($stdin), "Putting Afina to background");
+(threads::->create(sub { my $fh = $_[0]; while(<$fh>) { $silent || diag "afina: $_" } }, $stdout))->detach();
+
+alarm(10);
+
+sub afina_request_silent { # 0 tests
+	my ($request) = @_;
+	my $socket = IO::Socket::INET::->new(
+		PeerAddr => "127.0.0.1:8080",
+		Proto => "tcp"
+	) or die "socket: $!";
+	print($socket $request) or die "print: $!";
+	shutdown($socket, SHUT_WR()) or die "shutdown: $!";
+	my $received;
+	$received .= $_ while (<$socket>);
+	$received;
+}
+
+sub afina_request { # 3 tests
+	my ($request) = @_;
+	my $socket = IO::Socket::INET::->new(
+		PeerAddr => "127.0.0.1:8080",
+		Proto => "tcp"
+	);
+	ok($socket, "Connected to Afina");
+	ok(print($socket $request), "Sent request");
+	diag $request =~ s/^/-> /mrg;
+	ok(shutdown($socket, SHUT_WR()), "Closed writing end of connection");
+	my $received;
+	$received .= $_ while (<$socket>);
+	diag $received =~ s/^/<- /mrg;
+	$received;
+}
+
+sub afina_test { # 4 tests
+	my ($request, $response, $desc) = @_;
+	ref $response ? like(afina_request($request), $response, $desc);
+		: is(afina_request($request), $response, $desc);
+}
+
+afina_test("set foo 0 0 6\r\nfoobar\r\n", "STORED\r\n", "Set command");
+afina_test("get foo\r\n", "VALUE foo 0 6\r\nfoobar\r\nEND\r\n", "Get the value we just set");
+afina_test("get foo\r\nget foo\r\n", "VALUE foo 0 6\r\nfoobar\r\nEND\r\nVALUE foo 0 6\r\nfoobar\r\nEND\r\n", "Multiple commands");
+
+my %par_responses;
+$par_responses{$_}++ for (map { $_->join } map { threads::->create(\&afina_request_silent, $_) } map { sprintf "set bar 0 0 3\r\n%03d\r\n", $_ } 1..100);
+diag "Parallel test responses:";
+for (sort { $par_responses{$a} <=> $par_responses{$b} } keys %par_responses) {
+	diag "$par_responses{$_} ".($_=~s/([\r\n])/{"\r"=>'\r',"\n"=>'\n'}->{$1}/megr)."\n"
+}
+ok($par_responses{"STORED\r\n"}, "Afina replied with 'STORED' at least once");
+
+afina_test(
+	"set foo 0 0 3\r\nwtf\r\n"
+	."set bar 0 0 3\r\nzzz\r\n"
+	."get foo bar\r\n",
+	"STORED\r\n"
+	."STORED\r\n"
+	."VALUE foo 0 3\r\nwtf\r\n"
+	."VALUE bar 0 3\r\nzzz\r\n"
+	."END\r\n",
+	"Multiple commands with body"
+);
+
+afina_test(
+	"add test 0 0 6\r\nfoobar\r\n",
+	"STORED\r\n",
+	"Add non-existent key"
+);
+
+afina_test(
+	"add test 0 0 6\r\nfoobar\r\n",
+	"NOT_STORED\r\n",
+	"Don't add existent key"
+);
+
+afina_test(
+	"append test_ 0 0 3\r\nwtf\r\n",
+	"NOT_STORED\r\n",
+	"Don't append non-existent key"
+);
+
+afina_test(
+	"append test 0 0 3\r\nwtf\r\n",
+	"STORED\r\n",
+	"Append an existent key"
+);
+
+afina_test(
+	"get test\r\n",
+	"VALUE test 0 9\r\nfoobarwtf\r\nEND\r\n",
+	"Verify the append"
+);
+
+TODO: {
+	local $TODO = "Replace command isn't yet implemented in the parser";
+
+	afina_test(
+		"replace test_ 0 0 3\r\nwtf\r\n",
+		"NOT_STORED\r\n",
+		"Don't replace non-existent key"
+	);
+
+	afina_test(
+		"replace test 0 0 3\r\nzzz\r\n",
+		"STORED\r\n",
+		"Replace an existent key"
+	);
+
+	afina_test(
+		"get test\r\n",
+		"VALUE test 0 3\r\nzzz\r\nEND\r\n",
+		"Verify replace"
+	);
+}
+
+afina_test
+
+# Blocking backend is especially tricky to make terminate right, so we're taking no chances
+# hint: man 2 select
+ok(kill('KILL', $pid), "Stopped Afina");

--- a/test/network/test.pl
+++ b/test/network/test.pl
@@ -5,13 +5,14 @@ use threads;
 use threads::shared;
 use FindBin '$Bin';
 use IPC::Open3;
-use Test::More tests => 53;
+use Test::More tests => 61;
 use IO::Socket::INET;
 use Getopt::Long;
 
 my $backend = "blocking";
 my $silent = 0;
-my $afina = glob "$Bin/../../*/src/afina" or die "Couldn't find afina executable, please pass -a <path>\n";
+my $afina = glob "$Bin/../../*/src/afina";
+defined($afina) or die "Couldn't find afina executable, please pass -a <path>\n";
 
 GetOptions(
 	"backend=s" => \$backend,

--- a/test/network/test.pl
+++ b/test/network/test.pl
@@ -73,7 +73,7 @@ sub afina_request { # 3 tests
 
 sub afina_test { # 4 tests
 	my ($request, $response, $desc) = @_;
-	ref $response ? like(afina_request($request), $response, $desc);
+	ref $response ? like(afina_request($request), $response, $desc)
 		: is(afina_request($request), $response, $desc);
 }
 
@@ -153,7 +153,23 @@ TODO: {
 	);
 }
 
-afina_test
+afina_test(
+	"blablabla\r\n",
+	qr/ERROR/,
+	"Must report unknown command error to user"
+);
+
+afina_test(
+	"get\r\n",
+	qr/ERROR/,
+	"Must report no 'get' keys error to user"
+);
+
+afina_test(
+	"get\r\r",
+	qr/ERROR/,
+	"Must report desync errors to user"
+);
 
 # Blocking backend is especially tricky to make terminate right, so we're taking no chances
 # hint: man 2 select

--- a/test/network/test.pl
+++ b/test/network/test.pl
@@ -154,19 +154,13 @@ TODO: {
 }
 
 afina_test(
-	"blablabla\r\n",
+	"blablabla 0 0 0\r\n",
 	qr/ERROR/,
 	"Must report unknown command error to user"
 );
 
 afina_test(
-	"get\r\n",
-	qr/ERROR/,
-	"Must report no 'get' keys error to user"
-);
-
-afina_test(
-	"get\r\r",
+	"get var\r\r",
 	qr/ERROR/,
 	"Must report desync errors to user"
 );

--- a/test/network/test.pl
+++ b/test/network/test.pl
@@ -11,7 +11,7 @@ use Getopt::Long;
 
 my $backend = "blocking";
 my $silent = 0;
-my $afina = glob "$Bin/../../*/src/afina";
+my $afina = glob "$Bin/../../*/src/afina" or die "Couldn't find afina executable, please pass -a <path>\n";
 
 GetOptions(
 	"backend=s" => \$backend,


### PR DESCRIPTION
Используются только входящие в комплект Perl модули, но на CentOS7 придётся сделать `yum install perl-Test-Simple`.

Использование: из любой разумной директории запустить `perl .../путь/к/test/network/test.pl`. Скрипт предполагает, что в корне репозитория есть директория (обычно `build` или `cmake-build-debug`), внутри которой лежит исполняемый файл `src/afina`.

Можно добавить параметры командной строки:
 * `-a` / `--afina=путь/к/src/afina` - позволяет передать путь к программе вручную, если не удалось найти его автоматически
 * `-b` / `--backend=...` передаёт afina параметр `--network=...`, по умолчанию `blocking`
 * `-s` / `--silent` отключает печать того, что сама afina выводит на экран.

Скрипт печатает очень много информации, в частности, все отправленные и принятые по сети строки. Для проваленных тестов также выводится на экран ожидаемый (но не полученный) ответ. Тесты команды `replace` проваливаются, но помечаются `TODO`, поэтому не считаются за ошибки.

Совет: исправление ошибок лучше всего начинать с самого первого проваленного теста, потому что последующие ошибки могли быть вызваны им самим (например, упавшая afina приводит к феерической серии ошибок и роняет сам скрипт на половине).