### PR TITLE
Fix Parser

### DIFF
--- a/src/protocol/Parser.cpp
+++ b/src/protocol/Parser.cpp
@@ -24,7 +24,6 @@ bool Parser::Parse(const char *input, const size_t size, size_t &parsed) {
 
         switch (state) {
         case State::sName: {
-            parsed = 0;
             if (c == ' ') {
                 // std::cout << "parser debug: name='" << name << "'" << std::endl;
                 if (name == "set" || name == "add" || name == "append" || name == "prepend") {

--- a/src/protocol/Parser.cpp
+++ b/src/protocol/Parser.cpp
@@ -17,16 +17,14 @@ namespace Protocol {
 // See Parse.h
 bool Parser::Parse(const char *input, const size_t size, size_t &parsed) {
     size_t pos;
-    bool negative;
-    std::string curKey;
+    parsed = 0;
 
-    bytes = 0;
-    bool parse_complete = false;
     for (pos = 0; pos < size && !parse_complete; pos++) {
         char c = input[pos];
 
         switch (state) {
         case State::sName: {
+            parsed = 0;
             if (c == ' ') {
                 // std::cout << "parser debug: name='" << name << "'" << std::endl;
                 if (name == "set" || name == "add" || name == "append" || name == "prepend") {
@@ -156,7 +154,7 @@ bool Parser::Parse(const char *input, const size_t size, size_t &parsed) {
     }
 
     parsed += pos;
-    return state == State::sLF;
+    return parse_complete;
 }
 
 // See Parse.h
@@ -184,6 +182,8 @@ void Parser::Reset() {
     state = State::sName;
     name.clear();
     keys.clear();
+    curKey.clear();
+    parse_complete = false;
     flags = 0;
     bytes = 0;
     exprtime = 0;

--- a/src/protocol/Parser.h
+++ b/src/protocol/Parser.h
@@ -87,6 +87,10 @@ private:
     // including the delimiting \r\n. <bytes> may be zero (in which case
     // it's followed by an empty data block).
     uint32_t bytes;
+
+    bool negative;
+    std::string curKey;
+    bool parse_complete;
 };
 
 } // namespace Protocol


### PR DESCRIPTION
Парсер в некоторых случаях некорректно отрабатывал. Например, если команда "get foo bar\r\n" парсилась частями: Parse("get foo"), Parse(" bar\r\n"), то в результате мы бы в качестве ключей имели бы "" и "bar". Это связано с тем, что некоторые внутренние переменные существовали только внутри вызова Parse(). Также при вызове Parse() логично обнулять вначале parsed, так как после отработки функции в parsed должно быть количество обработанных байт в текущем вызове. Так же в некоторых граничных случаях функция возвращала True, в то время как не все данные еще были обработаны, к примеру, Parse("get foo\r") вернуло бы Истину, хотя должен был бы это сделать только после следующего вызова Parse("\n"). 