### PR TITLE
Реализация заглушки команды stats

### DIFF
--- a/include/afina/execute/Stats.h
+++ b/include/afina/execute/Stats.h
@@ -1,0 +1,21 @@
+#ifndef AFINA_EXECUTE_STATS_H
+#define AFINA_EXECUTE_STATS_H
+
+#include <string>
+
+#include "Command.h"
+
+namespace Afina {
+namespace Execute {
+
+class Stats : public Command {
+public:
+    Stats() {}
+    ~Stats() {}
+    void Execute(Storage &storage, const std::string &args, std::string &out) override;
+};
+
+} // namespace Execute
+} // namespace Afina
+
+#endif // AFINA_EXECUTE_STATS_H

--- a/src/execute/CMakeLists.txt
+++ b/src/execute/CMakeLists.txt
@@ -6,6 +6,7 @@ set(SOURCE_FILES
     Get.cpp
     Set.cpp
     Replace.cpp
+    Stats.cpp
 )
 
 add_library(Execute ${SOURCE_FILES})

--- a/src/execute/Stats.cpp
+++ b/src/execute/Stats.cpp
@@ -1,0 +1,14 @@
+#include <afina/Storage.h>
+#include <afina/execute/Stats.h>
+
+#include <iostream>
+#include <iterator>
+#include <sstream>
+
+namespace Afina {
+namespace Execute {
+
+void Stats::Execute(Storage &storage, const std::string &args, std::string &out) { out.assign("END"); }
+
+} // namespace Execute
+} // namespace Afina

--- a/src/protocol/Parser.cpp
+++ b/src/protocol/Parser.cpp
@@ -10,6 +10,7 @@
 #include <afina/execute/Delete.h>
 #include <afina/execute/Get.h>
 #include <afina/execute/Set.h>
+#include <afina/execute/Stats.h>
 
 namespace Afina {
 namespace Protocol {
@@ -27,12 +28,15 @@ bool Parser::Parse(const char *input, const size_t size, size_t &parsed) {
 
         switch (state) {
         case State::sName: {
-            if (c == ' ') {
+            if (c == ' ' || c == '\r') {
                 // std::cout << "parser debug: name='" << name << "'" << std::endl;
                 if (name == "set" || name == "add" || name == "append" || name == "prepend") {
                     state = State::spKey;
                 } else if (name == "get" || name == "gets") {
                     state = State::sgKey;
+                } else if (name == "stats") {
+                    state = State::sLF;
+                    continue;
                 } else {
                     throw std::runtime_error("Unknown command name");
                 }
@@ -174,6 +178,8 @@ std::unique_ptr<Execute::Command> Parser::Build(uint32_t &body_size) const {
         return std::unique_ptr<Execute::Command>(new Execute::Append(keys[0], flags, exprtime));
     } else if (name == "get") {
         return std::unique_ptr<Execute::Command>(new Execute::Get(keys));
+    } else if (name == "stats") {
+        return std::unique_ptr<Execute::Command>(new Execute::Stats());
     } else {
         throw std::runtime_error("Unsupported command");
     }

--- a/test/protocol/MemcachedParserTest.cpp
+++ b/test/protocol/MemcachedParserTest.cpp
@@ -6,6 +6,7 @@
 #include <afina/execute/Add.h>
 #include <afina/execute/Get.h>
 #include <afina/execute/Set.h>
+#include <afina/execute/Stats.h>
 
 #include <protocol/Parser.h>
 
@@ -78,4 +79,22 @@ TEST(MemcachedParserTest, SimpleGet) {
     ASSERT_EQ("ke", keys[0]);
     ASSERT_EQ("key2", keys[1]);
     ASSERT_EQ("super_long_key", keys[2]);
+}
+
+TEST(MemcachedParserTest, Stats) {
+    Protocol::Parser parser;
+
+    size_t consumed = 0;
+    bool cmd_avail = parser.Parse("stats\r\n", consumed);
+    ASSERT_TRUE(cmd_avail);
+    ASSERT_EQ(7, consumed);
+    ASSERT_EQ("stats", parser.Name());
+
+    uint32_t value_size;
+    std::unique_ptr<Execute::Command> cmd = parser.Build(value_size);
+    ASSERT_FALSE(cmd == nullptr);
+    ASSERT_EQ(0, value_size);
+
+    Execute::Stats *tmp = reinterpret_cast<Execute::Stats *>(cmd.get());
+	ASSERT_FALSE(tmp == nullptr);
 }


### PR DESCRIPTION
В противном случае Parser::Parse даже не возвращает true, что приводит к зависанию бенчмарка memcachetest.