### PR TITLE
Исправлены тесты для storage

### DIFF
--- a/test/storage/StorageTest.cpp
+++ b/test/storage/StorageTest.cpp
@@ -54,9 +54,9 @@ TEST(StorageTest, PutIfAbsent) {
 std::string
 pad_space(const std::string &s, size_t length)
 {
-    std::stringstream ss;
-    ss << std::setw(length) << s;
-    return ss.str();
+    std::string result = s;
+    result.resize(length, ' ');
+    return result;
 }
 
 TEST(StorageTest, BigTest) {

--- a/test/storage/StorageTest.cpp
+++ b/test/storage/StorageTest.cpp
@@ -2,6 +2,7 @@
 #include <iostream>
 #include <set>
 #include <vector>
+#include <iomanip>
 
 #include <storage/MapBasedGlobalLockImpl.h>
 #include <afina/execute/Get.h>
@@ -50,33 +51,32 @@ TEST(StorageTest, PutIfAbsent) {
     EXPECT_TRUE(value == "val1");
 }
 
-TEST(StorageTest, BigTest) {
-    MapBasedGlobalLockImpl storage(100000);
-
+std::string
+pad_space(const std::string &s, size_t length)
+{
     std::stringstream ss;
+    ss << std::setw(length) << s;
+    return ss.str();
+}
+
+TEST(StorageTest, BigTest) {
+    const size_t length = 20;
+    MapBasedGlobalLockImpl storage(2 * 100000 * length);
 
     for(long i=0; i<100000; ++i)
     {
-        ss << "Key" << i;
-        std::string key = ss.str();
-        ss.str("");
-        ss << "Val" << i;
-        std::string val = ss.str();
-        ss.str("");
+        auto key = pad_space("Key " + std::to_string(i), length);
+        auto val = pad_space("Val " + std::to_string(i), length);
         storage.Put(key, val);
     }
-    
+
     for(long i=99999; i>=0; --i)
     {
-        ss << "Key" << i;
-        std::string key = ss.str();
-        ss.str("");
-        ss << "Val" << i;
-        std::string val = ss.str();
-        ss.str("");
-        
+        auto key = pad_space("Key " + std::to_string(i), length);
+        auto val = pad_space("Val " + std::to_string(i), length);
+
         std::string res;
-        storage.Get(key, res);
+        EXPECT_TRUE(storage.Get(key, res));
 
         EXPECT_TRUE(val == res);
     }
@@ -84,42 +84,33 @@ TEST(StorageTest, BigTest) {
 }
 
 TEST(StorageTest, MaxTest) {
-    MapBasedGlobalLockImpl storage(1000);
+    const size_t length = 20;
+    MapBasedGlobalLockImpl storage(2 * 1000 * length);
 
     std::stringstream ss;
 
     for(long i=0; i<1100; ++i)
     {
-        ss << "Key" << i;
-        std::string key = ss.str();
-        ss.str("");
-        ss << "Val" << i;
-        std::string val = ss.str();
-        ss.str("");
+        auto key = pad_space("Key " + std::to_string(i), length);
+        auto val = pad_space("Val " + std::to_string(i), length);
         storage.Put(key, val);
     }
-    
+
     for(long i=100; i<1100; ++i)
     {
-        ss << "Key" << i;
-        std::string key = ss.str();
-        ss.str("");
-        ss << "Val" << i;
-        std::string val = ss.str();
-        ss.str("");
-        
+        auto key = pad_space("Key " + std::to_string(i), length);
+        auto val = pad_space("Val " + std::to_string(i), length);
+
         std::string res;
-        storage.Get(key, res);
+        EXPECT_TRUE(storage.Get(key, res));
 
         EXPECT_TRUE(val == res);
     }
-    
+
     for(long i=0; i<100; ++i)
     {
-        ss << "Key" << i;
-        std::string key = ss.str();
-        ss.str("");
-        
+        auto key = pad_space("Key " + std::to_string(i), length);
+
         std::string res;
         EXPECT_FALSE(storage.Get(key, res));
     }


### PR DESCRIPTION
Сейчас тесты написаны из предположения, что размер кеша, устанавливаемый при создании объекта - это число элементов в списке.

Это поведение исправлено на соответствующее условию.