### PR TITLE
Add support for running this server only on local interface

### DIFF
--- a/include/afina/concurrency/Executor.h
+++ b/include/afina/concurrency/Executor.h
@@ -28,7 +28,7 @@ class Executor {
         kStopped
     };
 
-    Executor(std::string name, int size);
+    Executor(const std::string &name, int size);
     ~Executor();
 
     /**
@@ -46,7 +46,7 @@ class Executor {
      * That function doesn't wait for function result. Function could always be written in a way to notify caller about
      * execution finished by itself
      */
-    template <typename F, typename... Types> bool Execute(F &&func, Types... args) {
+    template <typename F, typename... Types> bool Execute(F &&func, Types&&... args) {
         // Prepare "task"
         auto exec = std::bind(std::forward<F>(func), std::forward<Types>(args)...);
 

--- a/include/afina/network/Server.h
+++ b/include/afina/network/Server.h
@@ -17,8 +17,8 @@ namespace Network {
  */
 class Server {
 public:
-    Server(std::shared_ptr<Afina::Storage> ps, std::shared_ptr<Afina::Logging::Service> pl)
-        : pStorage(ps), pLogging(pl) {}
+    Server(std::shared_ptr<Afina::Storage> ps, std::shared_ptr<Afina::Logging::Service> pl, bool local)
+        : pStorage(ps), pLogging(pl), _local(local) {}
     virtual ~Server() {}
 
     /**
@@ -55,6 +55,9 @@ protected:
      * Logging service to be used in order to report application progress
      */
     std::shared_ptr<Afina::Logging::Service> pLogging;
+
+    // Whether to run locally
+    bool _local;
 };
 
 } // namespace Network

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -60,18 +60,22 @@ public:
 
         // Step 2: Configure network
         std::string network_type = "st_block";
+        bool local = false;
         if (options.count("network") > 0) {
             network_type = options["network"].as<std::string>();
         }
+        if (options.count("local") > 0) {
+            local = true;
+        }
 
         if (network_type == "st_block") {
-            server = std::make_shared<Afina::Network::STblocking::ServerImpl>(storage, logService);
+            server = std::make_shared<Afina::Network::STblocking::ServerImpl>(storage, logService, local);
         } else if (network_type == "mt_block") {
-            server = std::make_shared<Afina::Network::MTblocking::ServerImpl>(storage, logService);
+            server = std::make_shared<Afina::Network::MTblocking::ServerImpl>(storage, logService, local);
         } else if (network_type == "st_nonblock") {
-            server = std::make_shared<Afina::Network::STnonblock::ServerImpl>(storage, logService);
+            server = std::make_shared<Afina::Network::STnonblock::ServerImpl>(storage, logService, local);
         } else if (network_type == "mt_nonblock") {
-            server = std::make_shared<Afina::Network::MTnonblock::ServerImpl>(storage, logService);
+            server = std::make_shared<Afina::Network::MTnonblock::ServerImpl>(storage, logService, local);
         } else {
             throw std::runtime_error("Unknown network type");
         }
@@ -130,6 +134,7 @@ int main(int argc, char **argv) {
         options.add_options()("s,storage", "Type of storage service to use", cxxopts::value<std::string>());
         options.add_options()("n,network", "Type of network service to use", cxxopts::value<std::string>());
         options.add_options()("h,help", "Print usage info");
+        options.add_options()("l,local", "Bind to local interface only");
         options.parse(argc, argv);
 
         if (options.count("help") > 0) {

--- a/src/network/mt_blocking/ServerImpl.cpp
+++ b/src/network/mt_blocking/ServerImpl.cpp
@@ -28,7 +28,8 @@ namespace Network {
 namespace MTblocking {
 
 // See Server.h
-ServerImpl::ServerImpl(std::shared_ptr<Afina::Storage> ps, std::shared_ptr<Logging::Service> pl) : Server(ps, pl) {}
+ServerImpl::ServerImpl(std::shared_ptr<Afina::Storage> ps, std::shared_ptr<Logging::Service> pl, bool local)
+    : Server(ps, pl, local) {}
 
 // See Server.h
 ServerImpl::~ServerImpl() {}
@@ -47,9 +48,13 @@ void ServerImpl::Start(uint16_t port, uint32_t n_accept, uint32_t n_workers) {
 
     struct sockaddr_in server_addr;
     std::memset(&server_addr, 0, sizeof(server_addr));
-    server_addr.sin_family = AF_INET;         // IPv4
-    server_addr.sin_port = htons(port);       // TCP port number
-    server_addr.sin_addr.s_addr = INADDR_ANY; // Bind to any address
+    server_addr.sin_family = AF_INET;   // IPv4
+    server_addr.sin_port = htons(port); // TCP port number
+    if (!_local) {
+        server_addr.sin_addr.s_addr = INADDR_ANY; // Bind to any address
+    } else {
+        server_addr.sin_addr.s_addr = inet_addr("127.0.0.1"); // Bind only to loopback interface
+    }
 
     _server_socket = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP);
     if (_server_socket == -1) {

--- a/src/network/mt_blocking/ServerImpl.h
+++ b/src/network/mt_blocking/ServerImpl.h
@@ -20,7 +20,7 @@ namespace MTblocking {
  */
 class ServerImpl : public Server {
 public:
-    ServerImpl(std::shared_ptr<Afina::Storage> ps, std::shared_ptr<Logging::Service> pl);
+    ServerImpl(std::shared_ptr<Afina::Storage> ps, std::shared_ptr<Logging::Service> pl, bool local);
     ~ServerImpl();
 
     // See Server.h

--- a/src/network/mt_nonblocking/ServerImpl.cpp
+++ b/src/network/mt_nonblocking/ServerImpl.cpp
@@ -30,7 +30,8 @@ namespace Network {
 namespace MTnonblock {
 
 // See Server.h
-ServerImpl::ServerImpl(std::shared_ptr<Afina::Storage> ps, std::shared_ptr<Logging::Service> pl) : Server(ps, pl) {}
+ServerImpl::ServerImpl(std::shared_ptr<Afina::Storage> ps, std::shared_ptr<Logging::Service> pl, bool local)
+    : Server(ps, pl, local) {}
 
 // See Server.h
 ServerImpl::~ServerImpl() {}
@@ -50,9 +51,13 @@ void ServerImpl::Start(uint16_t port, uint32_t n_acceptors, uint32_t n_workers) 
     // Create server socket
     struct sockaddr_in server_addr;
     std::memset(&server_addr, 0, sizeof(server_addr));
-    server_addr.sin_family = AF_INET;         // IPv4
-    server_addr.sin_port = htons(port);       // TCP port number
-    server_addr.sin_addr.s_addr = INADDR_ANY; // Bind to any address
+    server_addr.sin_family = AF_INET;   // IPv4
+    server_addr.sin_port = htons(port); // TCP port number
+    if (!_local) {
+        server_addr.sin_addr.s_addr = INADDR_ANY; // Bind to any address
+    } else {
+        server_addr.sin_addr.s_addr = inet_addr("127.0.0.1"); // Bind to loopback interface only
+    }
 
     _server_socket = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP);
     if (_server_socket == -1) {

--- a/src/network/mt_nonblocking/ServerImpl.h
+++ b/src/network/mt_nonblocking/ServerImpl.h
@@ -23,7 +23,7 @@ class Worker;
  */
 class ServerImpl : public Server {
 public:
-    ServerImpl(std::shared_ptr<Afina::Storage> ps, std::shared_ptr<Logging::Service> pl);
+    ServerImpl(std::shared_ptr<Afina::Storage> ps, std::shared_ptr<Logging::Service> pl, bool local);
     ~ServerImpl();
 
     // See Server.h

--- a/src/network/st_blocking/ServerImpl.cpp
+++ b/src/network/st_blocking/ServerImpl.cpp
@@ -28,7 +28,8 @@ namespace Network {
 namespace STblocking {
 
 // See Server.h
-ServerImpl::ServerImpl(std::shared_ptr<Afina::Storage> ps, std::shared_ptr<Logging::Service> pl) : Server(ps, pl) {}
+ServerImpl::ServerImpl(std::shared_ptr<Afina::Storage> ps, std::shared_ptr<Logging::Service> pl, bool local)
+    : Server(ps, pl, local) {}
 
 // See Server.h
 ServerImpl::~ServerImpl() {}
@@ -59,9 +60,13 @@ void ServerImpl::Start(uint16_t port, uint32_t n_accept, uint32_t n_workers) {
     // Note we need to convert the port to network order
     struct sockaddr_in server_addr;
     std::memset(&server_addr, 0, sizeof(server_addr));
-    server_addr.sin_family = AF_INET;         // IPv4
-    server_addr.sin_port = htons(port);       // TCP port number
-    server_addr.sin_addr.s_addr = INADDR_ANY; // Bind to any address
+    server_addr.sin_family = AF_INET;   // IPv4
+    server_addr.sin_port = htons(port); // TCP port number
+    if (!_local) {
+        server_addr.sin_addr.s_addr = INADDR_ANY; // Bind to any address
+    } else {
+        server_addr.sin_addr.s_addr = inet_addr("127.0.0.1"); // Bind only to loopback interface
+    }
 
     // Arguments are:
     // - Family: IPv4

--- a/src/network/st_blocking/ServerImpl.h
+++ b/src/network/st_blocking/ServerImpl.h
@@ -20,7 +20,7 @@ namespace STblocking {
  */
 class ServerImpl : public Server {
 public:
-    ServerImpl(std::shared_ptr<Afina::Storage> ps, std::shared_ptr<Logging::Service> pl);
+    ServerImpl(std::shared_ptr<Afina::Storage> ps, std::shared_ptr<Logging::Service> pl, bool local);
     ~ServerImpl();
 
     // See Server.h

--- a/src/network/st_nonblocking/ServerImpl.cpp
+++ b/src/network/st_nonblocking/ServerImpl.cpp
@@ -29,7 +29,8 @@ namespace Network {
 namespace STnonblock {
 
 // See Server.h
-ServerImpl::ServerImpl(std::shared_ptr<Afina::Storage> ps, std::shared_ptr<Logging::Service> pl) : Server(ps, pl) {}
+ServerImpl::ServerImpl(std::shared_ptr<Afina::Storage> ps, std::shared_ptr<Logging::Service> pl, bool local)
+    : Server(ps, pl, local) {}
 
 // See Server.h
 ServerImpl::~ServerImpl() {}
@@ -49,9 +50,13 @@ void ServerImpl::Start(uint16_t port, uint32_t n_acceptors, uint32_t n_workers) 
     // Create server socket
     struct sockaddr_in server_addr;
     std::memset(&server_addr, 0, sizeof(server_addr));
-    server_addr.sin_family = AF_INET;         // IPv4
-    server_addr.sin_port = htons(port);       // TCP port number
-    server_addr.sin_addr.s_addr = INADDR_ANY; // Bind to any address
+    server_addr.sin_family = AF_INET;   // IPv4
+    server_addr.sin_port = htons(port); // TCP port number
+    if (!_local) {
+        server_addr.sin_addr.s_addr = INADDR_ANY; // Bind to any address
+    } else {
+        server_addr.sin_addr.s_addr = inet_addr("127.0.0.1"); // Bind only to loopback interface
+    }
 
     _server_socket = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP);
     if (_server_socket == -1) {

--- a/src/network/st_nonblocking/ServerImpl.h
+++ b/src/network/st_nonblocking/ServerImpl.h
@@ -23,7 +23,7 @@ class Worker;
  */
 class ServerImpl : public Server {
 public:
-    ServerImpl(std::shared_ptr<Afina::Storage> ps, std::shared_ptr<Logging::Service> pl);
+    ServerImpl(std::shared_ptr<Afina::Storage> ps, std::shared_ptr<Logging::Service> pl, bool local);
     ~ServerImpl();
 
     // See Server.h


### PR DESCRIPTION
Since our server has no authentication support, it may be insecure to run it on all interfaces in untrusted networks. So I decided to add support for running it only on local interface for the sake of security during testing.