### PR TITLE
fixed the bug

### DIFF
--- a/src/network/st_blocking/ServerImpl.cpp
+++ b/src/network/st_blocking/ServerImpl.cpp
@@ -217,6 +217,9 @@ void ServerImpl::OnRun() {
                         _logger->debug("Start command execution");
 
                         std::string result;
+                        if (argument_for_command.size()) {
+                            argument_for_command.resize(argument_for_command.size() - 2);
+                        }
                         command_to_execute->Execute(*pStorage, argument_for_command, result);
 
                         // Send response


### PR DESCRIPTION
В 189 строке размер аргумента в байтах увеличивался на два, чтобы считать "\r\n". Затем аргумент всюду передаётся вместе с этими лишними двумя байтами. Соответственно в хранилище держится лишнее, и, что самое страшное, клиент, сделавший get, получает не то значение, которое кто-то положил с помощью set