### PR TITLE
Made hw1 more consistent

### DIFF
--- a/src/storage/SimpleLRU.h
+++ b/src/storage/SimpleLRU.h
@@ -49,7 +49,7 @@ private:
     };
 
     // Maximum number of bytes could be stored in this cache.
-    // i.e all (keys+values) must be less the _max_size
+    // i.e all (keys+values) must be not greater than the _max_size
     std::size_t _max_size;
 
     // Main storage of lru_nodes, elements in this list ordered descending by "freshness": in the head


### PR DESCRIPTION
In Wiki and tests it is assumed that (keys+values) is not greater than _max_size.